### PR TITLE
Remove extra ENDIF

### DIFF
--- a/common.inc
+++ b/common.inc
@@ -90,7 +90,6 @@ CLP2	LDA %2+$200,Y
 	BNE CLP2
 	.ENDIF
 	.ENDIF
-	.ENDIF
 	.ENDM
 
 ; memory locations used by GETBYT / RREAD


### PR DESCRIPTION
The latest version of atasm (1.23) from https://github.com/CycoPH/atasm fails to compile the source for MyPicoDOS.

I tracked it down to an additional `.ENDIF` in common.inc.

This PR is to remove that line, and allow latest atasm to compile.
