### PR TITLE
Set BOOTQ before running XEX

### DIFF
--- a/common.inc
+++ b/common.inc
@@ -90,7 +90,6 @@ CLP2	LDA %2+$200,Y
 	BNE CLP2
 	.ENDIF
 	.ENDIF
-	.ENDIF
 	.ENDM
 
 ; memory locations used by GETBYT / RREAD

--- a/rreadcode.src
+++ b/rreadcode.src
@@ -24,6 +24,8 @@
 NE459	JMP $E459
 .endif
 
+BOOTQ = $9
+
 XREG	.BYTE 0   ; XREG
 YREG	.BYTE 0   ; YREG
 SECMASK	.BYTE 3   ; SECMASK
@@ -70,7 +72,8 @@ RREAD	STY YREG
 	PLA
 
 ; start program
-
+	LDA #1
+	STA BOOTQ
 	JSR INADJ
 	JSR RUADJ
 	JMP (10)


### PR DESCRIPTION
On [Fujinet](https://github.com/FujiNetWIFI/fujinet-platformio/) project, picoboot is being used to boot applications not associated with an ATR file.

I've noticed that in my own xex files launched from there, unless I specifically set BOOTQ to 1 in the launched application, the reset handler plays up and jumps to Self Test instead of running the correct reset handler.

I traced this to BOOTQ not being set to 1 and the OS handling it different during soft reset. After going to Self Test, pressing RESET again would run the application again. So alternating between Self Test and the Application every time reset is pressed.

Rather than every application setting BOOTQ, it would be useful to set it in the loader itself before running INIT and RUN addresses.

This MR is for that change.

I've tested this on both actual hardware and through Altirra, reset handling no longer jumping to self test.
